### PR TITLE
Add root README with setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,51 @@
+# FastKart Backend & Frontend
+
+This repository contains a Spring Boot backend and a Next.js admin frontend.
+
+## MySQL Configuration
+
+The backend expects a running MySQL instance with the following settings (see
+[`backend/src/main/resources/application.yml`](backend/src/main/resources/application.yml)):
+
+```yaml
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3306/test?useSSL=false&serverTimezone=UTC
+    username: root
+    password: 1234
+    driver-class-name: com.mysql.cj.jdbc.Driver
+```
+
+Ensure the `test` database exists or adjust the values to match your local
+MySQL setup.
+
+## Starting the Spring Boot Backend
+
+```bash
+cd backend
+./mvnw spring-boot:run
+```
+
+The application will start on `http://localhost:8080`.
+
+## Running the Next.js Frontend
+
+Before starting the frontend, set the `API_PROD_URL` environment variable to the
+base URL of the backend. Then start the development server:
+
+```bash
+cd nextjs-fastkart-admin
+export API_PROD_URL=http://localhost:8080/
+npm install
+npm run dev
+```
+
+On Windows use `set` instead of `export`:
+
+```cmd
+set API_PROD_URL=http://localhost:8080/
+npm install
+npm run dev
+```
+
+The Next.js application will be available at `http://localhost:3000`.


### PR DESCRIPTION
## Summary
- document MySQL config from `application.yml`
- describe how to start the Spring Boot backend
- document running the Next.js frontend with `API_PROD_URL`

## Testing
- `./mvnw -q test` *(fails: Failed to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6847a9afb8c88327a867ad5249d70db5