### PR TITLE
Remove extra registration address fields

### DIFF
--- a/nextjs-fastkart-admin/src/Components/Auth/RegistrationFormObjects.js
+++ b/nextjs-fastkart-admin/src/Components/Auth/RegistrationFormObjects.js
@@ -1,31 +1,24 @@
 import { descriptionSchema, emailSchema, nameSchema, passwordConfirmationSchema, passwordSchema, phoneSchema } from "../../Utils/Validation/ValidationSchemas";
 
-export const RegistrationValidationSchema = { name: nameSchema,
-    email: emailSchema,
-    password: passwordSchema,
-    password_confirmation: passwordConfirmationSchema,
-    store_name: nameSchema,
-    description: descriptionSchema,
-    city: nameSchema,
-    address: descriptionSchema,
-    pincode: nameSchema,
-    phone: phoneSchema,
-    country_id: nameSchema,
-    state_id: nameSchema
- }
+export const RegistrationValidationSchema = {
+  name: nameSchema,
+  email: emailSchema,
+  password: passwordSchema,
+  password_confirmation: passwordConfirmationSchema,
+  store_name: nameSchema,
+  description: descriptionSchema,
+  address: descriptionSchema,
+  phone: phoneSchema,
+};
 
- export const RegistrationInitialValues = {
-    name: "",
-    password: "",
-    email: "",
-    password_confirmation: "",
-    store_name: "",
-    description: "",
-    city: "",
-    address: "",
-    pincode: "",
-    phone: "",
-    country_id: "",
-    state_id: "",
-    country_code:"91"
-  }
+export const RegistrationInitialValues = {
+  name: "",
+  password: "",
+  email: "",
+  password_confirmation: "",
+  store_name: "",
+  description: "",
+  address: "",
+  phone: "",
+  country_code: "91",
+};

--- a/nextjs-fastkart-admin/src/Components/Auth/UserAddress.js
+++ b/nextjs-fastkart-admin/src/Components/Auth/UserAddress.js
@@ -1,65 +1,20 @@
 import { Field } from "formik";
 import { Col } from "reactstrap";
 import { ReactstrapInput } from "../ReactstrapFormik";
-import SearchableSelectInput from "../InputFields/SearchableSelectInput";
-import { useQuery } from "@tanstack/react-query";
-import { country } from "../../Utils/AxiosUtils/API";
-import request from "../../Utils/AxiosUtils";
 
-const UserAddress = ({ values }) => {
-  const { data } = useQuery([country], () => request({ url: country }), { select: (res) => res.data.map((country) => ({ id: country.id, name: country.name, state: country.state })) });
+const UserAddress = () => {
   return (
     <>
-      <Col sm="4">
-        <SearchableSelectInput
-          nameList={[
-            {
-              formfloat: "true",
-              notitle: "true",
-              name: "country_id",
-              floatlabel: "Country",
-              require: "true",
-              inputprops: {
-                name: "country_id",
-                id: "country_id",
-                options: data,
-                defaultOption: "Select state",
-              },
-              disabled: values?.["country_id"] ? false : true,
-            },
-          ]}
-        />
-      </Col>
-      <Col sm="4">
-        <div className="form-floating theme-form-floating log-in-form">
-          <SearchableSelectInput
-            nameList={[
-              {
-                floatlabel: "State",
-                formfloat: "true",
-                name: "state_id",
-                notitle: "true",
-                require: "true",
-                inputprops: {
-                  name: "state_id",
-                  id: "state_id",
-                  options: values?.["country_id"] ? data?.filter((country) => Number(country.id) === Number(values?.["country_id"]))?.[0]?.["state"] : [],
-                  defaultOption: "Select state",
-                },
-                disabled: values?.["country_id"] ? false : true,
-              },
-            ]}
-          />
-        </div>
-      </Col>
-      <Col sm="4" xs="6">
-        <Field name="city" component={ReactstrapInput} type="text" className="form-control" id="city" placeholder="City" label="City" />
-      </Col>
       <Col xs="12">
-        <Field name="address" component={ReactstrapInput} type="textarea" className="form-control" id="address" placeholder="Address" label="Address" />
-      </Col>
-      <Col sm="6">
-        <Field name="pincode" component={ReactstrapInput} type="text" className="form-control" id="pincode" placeholder="Pincode" label="Pincode" />
+        <Field
+          name="address"
+          component={ReactstrapInput}
+          type="textarea"
+          className="form-control"
+          id="address"
+          placeholder="Address"
+          label="Address"
+        />
       </Col>
     </>
   );

--- a/nextjs-fastkart-admin/src/app/[lng]/auth/register/page.js
+++ b/nextjs-fastkart-admin/src/app/[lng]/auth/register/page.js
@@ -5,7 +5,6 @@ import { Col, Container, Row } from "reactstrap";
 import { useTranslation } from "@/app/i18n/client";
 import { Form, Formik } from "formik";
 import { RegistrationInitialValues, RegistrationValidationSchema } from "@/Components/Auth/RegistrationFormObjects";
-import UserAddress from "@/Components/Auth/UserAddress";
 import UserContact from "@/Components/Auth/UserContact";
 import UserPersonalInfo from "@/Components/Auth/UserPersonalInfo";
 import Btn from "@/Elements/Buttons/Btn";
@@ -42,7 +41,6 @@ const VendorRegister = () => {
                                     {({ values, errors }) => (
                                         <Form className="row g-4">
                                             <UserPersonalInfo />
-                                            <UserAddress values={values} />
                                             <UserContact />
                                             <Col xs={12}>
                                                 <Btn title="Submit" className="btn btn-animation w-100 justify-content-center" type="submit" color="false" loading={Number(isLoading)} />


### PR DESCRIPTION
## Summary
- streamline validation/defaults by removing location fields
- drop location selection inputs from `UserAddress`
- simplify registration page without address section

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847b053b81c8327a9cec7c1b5919867