### PR TITLE
Update API base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ cd backend
 
 The application will start on `http://localhost:8080`.
 
+Ensure the `API_PROD_URL` environment variable points to the backend API
+(`http://localhost:8080/api/`) when running the frontend.
+
 ## Running the Next.js Frontend
 
 Before starting the frontend, set the `API_PROD_URL` environment variable to the
@@ -35,7 +38,7 @@ base URL of the backend. Then start the development server:
 
 ```bash
 cd nextjs-fastkart-admin
-export API_PROD_URL=http://localhost:8080/
+export API_PROD_URL=http://localhost:8080/api/
 npm install
 npm run dev
 ```
@@ -43,7 +46,7 @@ npm run dev
 On Windows use `set` instead of `export`:
 
 ```cmd
-set API_PROD_URL=http://localhost:8080/
+set API_PROD_URL=http://localhost:8080/api/
 npm install
 npm run dev
 ```

--- a/nextjs-fastkart-admin/next.config.js
+++ b/nextjs-fastkart-admin/next.config.js
@@ -3,8 +3,8 @@ const nextConfig = {
   reactStrictMode: false,
   swcMinify: true,
   env: {
-    // For Local Server
-    API_PROD_URL: "http://localhost:8080/api/",
+    // For Local or deployment environments
+    API_PROD_URL: process.env.API_PROD_URL || "http://localhost:8080/api/",
   },
   redirects: async () => {
     return [


### PR DESCRIPTION
## Summary
- note API_PROD_URL in docs
- allow overriding API_PROD_URL in config

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847b04e04f8832794a78e36e60122c1