### PR TITLE
Refactor admin registration

### DIFF
--- a/nextjs-fastkart-admin/src/Components/Auth/RegistrationFormObjects.js
+++ b/nextjs-fastkart-admin/src/Components/Auth/RegistrationFormObjects.js
@@ -1,24 +1,17 @@
-import { descriptionSchema, emailSchema, nameSchema, passwordConfirmationSchema, passwordSchema, phoneSchema } from "../../Utils/Validation/ValidationSchemas";
+import { emailSchema, nameSchema, passwordConfirmationSchema, passwordSchema } from "../../Utils/Validation/ValidationSchemas";
 
 export const RegistrationValidationSchema = {
-  name: nameSchema,
+  firstName: nameSchema,
+  lastName: nameSchema,
   email: emailSchema,
   password: passwordSchema,
-  password_confirmation: passwordConfirmationSchema,
-  store_name: nameSchema,
-  description: descriptionSchema,
-  address: descriptionSchema,
-  phone: phoneSchema,
+  confirmPassword: passwordConfirmationSchema,
 };
 
 export const RegistrationInitialValues = {
-  name: "",
-  password: "",
+  firstName: "",
+  lastName: "",
   email: "",
-  password_confirmation: "",
-  store_name: "",
-  description: "",
-  address: "",
-  phone: "",
-  country_code: "91",
+  password: "",
+  confirmPassword: "",
 };

--- a/nextjs-fastkart-admin/src/Components/Auth/UserPersonalInfo.js
+++ b/nextjs-fastkart-admin/src/Components/Auth/UserPersonalInfo.js
@@ -6,7 +6,10 @@ const UserPersonalInfo = () => {
   return (
     <>
       <Col sm="6">
-        <Field name="name" type="text" component={ReactstrapInput} className="form-control" id="name" placeholder="Name" label="Name" />
+        <Field name="firstName" type="text" component={ReactstrapInput} className="form-control" id="firstName" placeholder="First Name" label="FirstName" />
+      </Col>
+      <Col sm="6">
+        <Field name="lastName" type="text" component={ReactstrapInput} className="form-control" id="lastName" placeholder="Last Name" label="LastName" />
       </Col>
       <Col sm="6">
         <Field name="email" type="email" component={ReactstrapInput} className="form-control" id="email" placeholder="Email" label="Email" />
@@ -15,13 +18,7 @@ const UserPersonalInfo = () => {
         <Field name="password" type="password" component={ReactstrapInput} className="form-control" id="password" placeholder="Password" label="Password" />
       </Col>
       <Col sm="6">
-        <Field name="password_confirmation" type="password" component={ReactstrapInput} className="form-control" id="password_confirmation" placeholder="Confirm Password" label="ConfirmPassword" />
-      </Col>
-      <Col sm="6">
-        <Field name="store_name" type="text" component={ReactstrapInput} className="form-control" id="store_name" placeholder="Store Name" label="StoreName" />
-      </Col>
-      <Col sm="6">
-        <Field name="description" type="textarea" component={ReactstrapInput} className="form-control" id="description" placeholder="Store Description" label="StoreDescription" />
+        <Field name="confirmPassword" type="password" component={ReactstrapInput} className="form-control" id="confirmPassword" placeholder="Confirm Password" label="ConfirmPassword" />
       </Col>
     </>
   );

--- a/nextjs-fastkart-admin/src/app/[lng]/auth/register/page.js
+++ b/nextjs-fastkart-admin/src/app/[lng]/auth/register/page.js
@@ -5,18 +5,17 @@ import { Col, Container, Row } from "reactstrap";
 import { useTranslation } from "@/app/i18n/client";
 import { Form, Formik } from "formik";
 import { RegistrationInitialValues, RegistrationValidationSchema } from "@/Components/Auth/RegistrationFormObjects";
-import UserContact from "@/Components/Auth/UserContact";
 import UserPersonalInfo from "@/Components/Auth/UserPersonalInfo";
 import Btn from "@/Elements/Buttons/Btn";
 import { YupObject } from "@/Utils/Validation/ValidationSchemas";
 import useCreate from "@/Utils/Hooks/useCreate";
-import { store } from "@/Utils/AxiosUtils/API";
+import { register } from "@/Utils/AxiosUtils/API";
 import I18NextContext from "@/Helper/I18NextContext";
 
 const VendorRegister = () => {
     const { i18Lang } = useContext(I18NextContext);
     const { t } = useTranslation(i18Lang, 'common');
-    const { mutate, isLoading } = useCreate(store, false, `/${i18Lang}/auth/login`);
+    const { mutate, isLoading } = useCreate(register, false, `/${i18Lang}/auth/login`);
     return (
         <section className='log-in-section section-b-space'>
             <Container className='w-100'>
@@ -25,7 +24,7 @@ const VendorRegister = () => {
                         <div className="log-in-box">
                             <div className="log-in-title">
                                 <h3>{"Welcome To Fastkart"}</h3>
-                                <h4>{"Setup Your Store Information"}</h4>
+                                <h4>{"Create Admin Account"}</h4>
                             </div>
                             <div className="input-box">
                                 <Formik
@@ -34,14 +33,12 @@ const VendorRegister = () => {
                                         ...RegistrationValidationSchema,
                                     })}
                                     onSubmit={(values) => {
-                                        values["status"] = 1;
                                         mutate(values);
                                     }}
                                 >
                                     {({ values, errors }) => (
                                         <Form className="row g-4">
                                             <UserPersonalInfo />
-                                            <UserContact />
                                             <Col xs={12}>
                                                 <Btn title="Submit" className="btn btn-animation w-100 justify-content-center" type="submit" color="false" loading={Number(isLoading)} />
                                                 <div className="sign-up-box">


### PR DESCRIPTION
## Summary
- streamline admin registration flow
- simplify registration fields to match `Admin` entity

## Testing
- `npm test` *(fails: Could not read package.json)*
- `./mvnw test` *(fails: Failed to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6847b50704e883279354ee9ae861e347